### PR TITLE
Domain input issue when setting up via CLI

### DIFF
--- a/files/etc/nginx/sites-available/laravel
+++ b/files/etc/nginx/sites-available/laravel
@@ -1,6 +1,6 @@
 server {
     listen 80;
-    server_name _ DOMAIN.org www.DOMAIN.org;
+    server_name _ DOMAIN www.DOMAIN;
     root /var/www/laravel/public;
 
     add_header X-Frame-Options "SAMEORIGIN";


### PR DESCRIPTION
I'm using the DigitalOcean's 1-click installation for Laravel. So when I initially input my domain in the setup via CLI. The domain I inputted gets appended with ".org" TLD always even if I declare my domain's TLD.

Example:
domain.com

Results:
domain.com.org

Expects:
domain.com

This also triggers an error when setting up LetsEncrypt SSL certificates because the domain being issued is:

Results
domain.com.org
www.domain.com.org

Expects:
domain.com
www.domain.com

By the way, thank you for this package. :)